### PR TITLE
Implement notification permission handling with DataStore persistence

### DIFF
--- a/app/src/main/java/com/example/foldtracker/datastore/DataStoreKeys.kt
+++ b/app/src/main/java/com/example/foldtracker/datastore/DataStoreKeys.kt
@@ -23,6 +23,7 @@ object DataStoreKeys {
     val HINGE_ANGLE_KEY = intPreferencesKey("hinge_angle_key")
     val DAILY_LIMIT_KEY = intPreferencesKey("daily_limit_key")
     val LAST_NOTIFIED_DATE_KEY = stringPreferencesKey("last_notified_date_key")
+    val NOTIFICATION_PERMISSION_REQUESTED_KEY = booleanPreferencesKey("notification_permission_requested_key")
 }
 
 // Preferences Manager

--- a/app/src/main/java/com/example/foldtracker/repository/CounterRepository.kt
+++ b/app/src/main/java/com/example/foldtracker/repository/CounterRepository.kt
@@ -22,4 +22,6 @@ interface CounterRepository {
     fun getTodayDate(): String
     suspend fun sendDailyLimitNotification(dailyLimit: Int)
     fun observePreferences(): Flow<Preferences>
+    suspend fun isNotificationPermissionRequested(): Boolean
+    suspend fun setNotificationPermissionRequested(requested: Boolean)
 }

--- a/app/src/main/java/com/example/foldtracker/repository/CounterRepositoryImpl.kt
+++ b/app/src/main/java/com/example/foldtracker/repository/CounterRepositoryImpl.kt
@@ -158,4 +158,13 @@ class CounterRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    override suspend fun isNotificationPermissionRequested(): Boolean =
+        dataStore.data.map { it[DataStoreKeys.NOTIFICATION_PERMISSION_REQUESTED_KEY] ?: false }.first()
+
+    override suspend fun setNotificationPermissionRequested(requested: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[DataStoreKeys.NOTIFICATION_PERMISSION_REQUESTED_KEY] = requested
+        }
+    }
 } 

--- a/app/src/main/java/com/example/foldtracker/viewmodel/CounterViewModel.kt
+++ b/app/src/main/java/com/example/foldtracker/viewmodel/CounterViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.foldtracker.repository.CounterRepository
 import com.example.foldtracker.widget.FoldCountWidget
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -130,6 +131,16 @@ class CounterViewModel @Inject constructor(
         viewModelScope.launch {
             repository.setDailyLimit(newLimit)
             _dailyLimit.value = newLimit
+        }
+    }
+
+    suspend fun isNotificationPermissionRequested(): Boolean {
+        return repository.isNotificationPermissionRequested()
+    }
+
+    fun setNotificationPermissionRequested(requested: Boolean) {
+        viewModelScope.launch(Dispatchers.IO) {
+            repository.setNotificationPermissionRequested(requested)
         }
     }
 


### PR DESCRIPTION
## Changes
- Added notification permission handling that follows Android best practices
- Implemented DataStore persistence to track if notification permission has been requested
- Show notification permission dialog only on first app launch
- Enhanced foreground notification to include fold count information
- Removed redundant permission checking logic
- Updated CounterViewModel and CounterRepository to support notification permission tracking

## Testing
- Tested on Android 13+ devices to verify permission request behavior
- Verified that permission is only requested once
- Confirmed that notification content shows fold count information correctly