### PR TITLE
Add toolbar with back button and overflow menu to Statistics Screen

### DIFF
--- a/app/src/main/java/com/example/foldtracker/core/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/foldtracker/core/navigation/AppNavigation.kt
@@ -18,7 +18,7 @@ fun AppNavigation(viewModel: CounterViewModel) {
         }
 
         composable("stats_screen") {
-            StatsScreen(viewModel = viewModel)
+            StatsScreen(viewModel = viewModel, navController = navController)
         }
     }
 }

--- a/app/src/main/java/com/example/foldtracker/feature/stats/ui/StatsScreen.kt
+++ b/app/src/main/java/com/example/foldtracker/feature/stats/ui/StatsScreen.kt
@@ -10,8 +10,20 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -23,55 +35,146 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import com.example.foldtracker.core.ui.CounterCard
 import com.example.foldtracker.core.ui.gradientBackground
 import com.example.foldtracker.feature.counter.CounterViewModel
 import com.example.foldtracker.feature.counter.ui.DailyLimitCard
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun StatsScreen(viewModel: CounterViewModel) {
+fun StatsScreen(viewModel: CounterViewModel, navController: NavController) {
     val averageFolds by viewModel.averageFolds.collectAsState()
     val yearlyProjection by viewModel.yearlyProjection.collectAsState()
     val hingeAngle by viewModel.hingeAngle.collectAsState()
 
     var isDailyLimitCardExpanded by remember { mutableStateOf(false) }
+    var showOverflowMenu by remember { mutableStateOf(false) }
+    var showAboutDialog by remember { mutableStateOf(false) }
+    var showHelpDialog by remember { mutableStateOf(false) }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(gradientBackground())
-            .padding(16.dp)
-            .pointerInput(isDailyLimitCardExpanded) {
-                detectTapGestures { offset ->
-                    if (isDailyLimitCardExpanded) {
-                        isDailyLimitCardExpanded = false
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Statistics") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showOverflowMenu = true }) {
+                        Icon(
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = "More options"
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = showOverflowMenu,
+                        onDismissRequest = { showOverflowMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("About") },
+                            onClick = {
+                                showOverflowMenu = false
+                                showAboutDialog = true
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Help") },
+                            onClick = {
+                                showOverflowMenu = false
+                                showHelpDialog = true
+                            }
+                        )
                     }
                 }
-            },
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            "Statistics",
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.outlineVariant,
-            fontWeight = FontWeight.Bold
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Row(
+            )
+        }
+    ) { paddingValues ->
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly
+                .fillMaxSize()
+                .background(gradientBackground())
+                .padding(paddingValues)
+                .padding(16.dp)
+                .pointerInput(isDailyLimitCardExpanded) {
+                    detectTapGestures { _ ->
+                        if (isDailyLimitCardExpanded) {
+                            isDailyLimitCardExpanded = false
+                        }
+                    }
+                },
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            CounterCard("Avg. Weekly Folds", String.format("%.2f", averageFolds))
-            CounterCard("Hinge Angle", "$hingeAngle°")
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                CounterCard("Avg. Weekly Folds", String.format("%.2f", averageFolds))
+                CounterCard("Hinge Angle", "$hingeAngle°")
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            CounterCard("Yearly Projection", String.format("%d", yearlyProjection))
+            Spacer(modifier = Modifier.height(16.dp))
+            DailyLimitCard(viewModel = viewModel, isExpanded = isDailyLimitCardExpanded) {
+                isDailyLimitCardExpanded = !isDailyLimitCardExpanded
+            }
         }
-        Spacer(modifier = Modifier.height(16.dp))
-        CounterCard("Yearly Projection", String.format("%d", yearlyProjection))
-        Spacer(modifier = Modifier.height(16.dp))
-        DailyLimitCard(viewModel = viewModel, isExpanded = isDailyLimitCardExpanded) {
-            isDailyLimitCardExpanded = !isDailyLimitCardExpanded
-        }
+    }
+
+    // About Dialog
+    if (showAboutDialog) {
+        AlertDialog(
+            onDismissRequest = { showAboutDialog = false },
+            title = { Text("About FoldTracker") },
+            text = {
+                Column {
+                    Text("FoldTracker v1.0")
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text("An application to track and analyze your device folding habits.")
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text("Developed by: FoldTracker Team")
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showAboutDialog = false }) {
+                    Text("Close")
+                }
+            }
+        )
+    }
+
+    // Help Dialog
+    if (showHelpDialog) {
+        AlertDialog(
+            onDismissRequest = { showHelpDialog = false },
+            title = { Text("Help") },
+            text = {
+                Column {
+                    Text("Statistics Screen Guide:", fontWeight = FontWeight.Bold)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text("• Avg. Weekly Folds: The average number of times you fold your device per week.")
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text("• Hinge Angle: The current angle of your device's hinge.")
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text("• Yearly Projection: Estimated number of folds for the entire year based on your current usage.")
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text("• Daily Limit: Set and track your daily folding limit to prevent overuse.")
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showHelpDialog = false }) {
+                    Text("Close")
+                }
+            }
+        )
     }
 }


### PR DESCRIPTION
## Description
This PR implements the toolbar enhancement for the Statistics Screen according to the PRD specifications.

### Changes Made:
- Added a Material3 TopAppBar with:
  - A back button on the left that navigates back to the Counter Screen
  - "Statistics" as the title in the center
  - An overflow menu icon (three vertical dots) on the right
- Implemented the overflow menu with two options:
  - "About" - displays information about the application
  - "Help" - provides guidance on using the statistics screen
- Created dialog implementations:
  - About Dialog: Shows app version, purpose, and developer info with a Close button
  - Help Dialog: Provides explanations for each statistic shown with a Close button
- Maintained visual consistency with the existing app design by preserving the gradient background
- Adjusted the layout to accommodate the toolbar with proper spacing between elements

### Technical Details:
- Updated AppNavigation.kt to pass the NavController to StatsScreen
- Enhanced StatsScreen.kt with the toolbar, overflow menu, and dialogs
- Used the AutoMirrored version of the ArrowBack icon for proper RTL support
- Ensured proper state management for menu and dialog visibility

### Testing:
- Built and tested the app to confirm there are no compilation errors
- Verified that the back button navigates correctly to the Counter Screen
- Confirmed that the overflow menu opens and closes as expected
- Verified that the About and Help dialogs display correctly and can be closed

Resolves the requirements specified in the Statistics Screen Toolbar Enhancement PRD.